### PR TITLE
Remove client import from Common class

### DIFF
--- a/Forge/src/main/java/com/christofmeg/fastentitytransfer/FastEntityTransfer.java
+++ b/Forge/src/main/java/com/christofmeg/fastentitytransfer/FastEntityTransfer.java
@@ -1,6 +1,5 @@
 package com.christofmeg.fastentitytransfer;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock;


### PR DESCRIPTION
The mod class was importing a Client class (Minecraft) in a common environment. This means that it would crash when running on a dedicated server. I removed the unnecessary import.